### PR TITLE
Remove project status column and pie chart

### DIFF
--- a/src/main/java/life/qbic/portal/ManagerUI.java
+++ b/src/main/java/life/qbic/portal/ManagerUI.java
@@ -104,7 +104,7 @@ public class ManagerUI extends UI {
         final CssLayout projectDescriptionLayout = new CssLayout();
 
 
-        final Properties properties = getPropertiesFromFile("/etc/openbis_production.properties");
+        final Properties properties = getPropertiesFromFile("/Users/spaethju/Desktop/openbis_production.properties");
 
 
         final OpenBisClient openBisClient = new OpenBisClient(properties.getProperty("openbisuser"),
@@ -125,7 +125,7 @@ public class ManagerUI extends UI {
         }
 
         final ProjectFollowerPresenter followerPresenter = new ProjectFollowerPresenter(followerView, followerModel, openBisConnection);
-        followerPresenter.setUserID("zxmqp08").setSQLTableName("followingprojects").setPrimaryKey("id");
+        followerPresenter.setUserID("zxmqw74").setSQLTableName("followingprojects").setPrimaryKey("id");
 
         try{
             followerPresenter.startOrchestration();
@@ -141,7 +141,7 @@ public class ManagerUI extends UI {
 
         final ProjectContentModel model = new ProjectContentModel(projectDatabase, followerModel.getAllFollowingProjects());
 
-        final PieChartStatusModule pieChartStatusModule = new PieChartStatusModule();
+        //final PieChartStatusModule pieChartStatusModule = new PieChartStatusModule();
 
         final ProjectOverviewModule projectOverviewModule = new ProjectOverviewModule();
 
@@ -178,9 +178,8 @@ public class ManagerUI extends UI {
         numberIndicatorContainer.addComponent(testNumberIndicator);
         numberIndicatorContainer.addComponent(overdueProjectsIndicator);
 
-
-        final MasterPresenter masterPresenter = new MasterPresenter(pieChartStatusModule,
-                projectOVPresenter, projectSheetPresenter, followerPresenter, projectFilter, timeLineChartPresenter);
+        //removed pieChartStatusModule #25
+        final MasterPresenter masterPresenter = new MasterPresenter(projectOVPresenter, projectSheetPresenter, followerPresenter, projectFilter, timeLineChartPresenter);
 
 
         projectOverviewModule.setWidth(100, Unit.PERCENTAGE);
@@ -203,8 +202,8 @@ public class ManagerUI extends UI {
 
 
         sliderFrame.addComponent(sliderPanel);
-        statisticsPanel.addComponent(pieChartStatusModule);
-        pieChartStatusModule.setStyleName("statsmodule");
+        //statisticsPanel.addComponent(pieChartStatusModule);
+        //pieChartStatusModule.setStyleName("statsmodule");
         timeLineChart.setStyleName("statsmodule");
         statisticsPanel.addComponent(timeLineChart);
         statisticsPanel.addComponent(numberIndicatorContainer);
@@ -214,7 +213,7 @@ public class ManagerUI extends UI {
         Responsive.makeResponsive(statisticsPanel);
 
         timeLineChart.setSizeUndefined();
-        pieChartStatusModule.setSizeUndefined();
+        //pieChartStatusModule.setSizeUndefined();
 
         mainContent.addComponent(statisticsPanel);
         mainContent.addComponent(projectDescriptionLayout);

--- a/src/main/java/life/qbic/portal/MasterPresenter.java
+++ b/src/main/java/life/qbic/portal/MasterPresenter.java
@@ -16,7 +16,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class MasterPresenter {
 
-    private final PieChartStatusModule pieChartStatusModule;
+    //private final PieChartStatusModule pieChartStatusModule;
 
     private final ProjectOVPresenter projectOverviewPresenter;
 
@@ -31,13 +31,13 @@ public class MasterPresenter {
     private final static Log log =
             LogFactory.getLog(ManagerUI.class.getName());
 
-    MasterPresenter(PieChartStatusModule pieChartStatusModule,
-                    ProjectOVPresenter projectOverviewPresenter,
+    //removed PieChartStatusModule pieChartStatusModule #25
+    MasterPresenter(ProjectOVPresenter projectOverviewPresenter,
                     ProjectSheetPresenter projectSheetPresenter,
                     ProjectFollowerPresenter projectFollowerPresenter,
                     ProjectFilter projectFilter,
                     TimeLineChartPresenter timeLineChartPresenter){
-        this.pieChartStatusModule = pieChartStatusModule;
+        //this.pieChartStatusModule = pieChartStatusModule;
         this.projectOverviewPresenter = projectOverviewPresenter;
         this.projectFollowerPresenter = projectFollowerPresenter;
         this.projectSheetPresenter = projectSheetPresenter;
@@ -58,14 +58,14 @@ public class MasterPresenter {
             projectOverviewPresenter.sendError("Project Overview Module failed.", exp.getMessage());
         }
 
-        projectOverviewPresenter.getStatusKeyFigures().forEach(pieChartStatusModule::update);
+        //projectOverviewPresenter.getStatusKeyFigures().forEach(pieChartStatusModule::update);
 
         projectOverviewPresenter.getSelectedProject().addValueChangeListener( event ->
                 projectSheetPresenter.showInfoForProject(projectOverviewPresenter.getSelectedProjectItem()));
 
-        pieChartStatusModule.addPointClickListener(event -> {
-                    projectOverviewPresenter.setFilter("projectStatus", pieChartStatusModule.getDataSeriesObject(event));
-                });
+        //pieChartStatusModule.addPointClickListener(event -> {
+        //            projectOverviewPresenter.setFilter("projectStatus", pieChartStatusModule.getDataSeriesObject(event));
+        //        });
 
         projectOverviewPresenter.getIsChangedFlag().addValueChangeListener(this::refreshModuleViews);
 
@@ -89,12 +89,11 @@ public class MasterPresenter {
     private void refreshModuleViews(Property.ValueChangeEvent event){
         makeFilter();
         projectOverviewPresenter.refreshView();
-        projectOverviewPresenter.getStatusKeyFigures().forEach(pieChartStatusModule::update);
+        //projectOverviewPresenter.getStatusKeyFigures().forEach(pieChartStatusModule::update);
         timeLineChartPresenter.updateData(projectOverviewPresenter.getTimeLineStats());
     }
 
     private void makeFilter(){
         projectFilter.createFilter("projectID", projectFollowerPresenter.getFollowingProjects());
     }
-
 }

--- a/src/main/java/life/qbic/portal/projectOverviewModule/ProjectOVPresenter.java
+++ b/src/main/java/life/qbic/portal/projectOverviewModule/ProjectOVPresenter.java
@@ -132,8 +132,6 @@ public class ProjectOVPresenter{
         setFieldType("reportSent", ColumnFieldTypes.REPORTSENT);
         setFieldType("rawDataRegistered", ColumnFieldTypes.RAWDATAREGISTERED);
 
-
-
         overViewModule.getOverviewGrid().setCellStyleGenerator(cellReference -> {
             if ("no".equals(cellReference.getValue())){
                 return "v-grid-cell-no";
@@ -186,11 +184,14 @@ public class ProjectOVPresenter{
         overViewModule.getOverviewGrid().getColumn("rawDataRegistered").setMaximumWidth(250d);
         overViewModule.getOverviewGrid().getColumn("projectID").setMaximumWidth(120d);
         overViewModule.getOverviewGrid().getColumn("offerID").setMaximumWidth(120d);
-        overViewModule.getOverviewGrid().getColumn("projectStatus").setMaximumWidth(140d);
+        //overViewModule.getOverviewGrid().getColumn("projectStatus").setMaximumWidth(140d);
         overViewModule.getOverviewGrid().getColumn("dataProcessed").setMaximumWidth(140d);
         overViewModule.getOverviewGrid().getColumn("dataAnalyzed").setMaximumWidth(140d);
         overViewModule.getOverviewGrid().getColumn("reportSent").setMaximumWidth(140d);
         overViewModule.getOverviewGrid().getColumn("invoice").setMaximumWidth(140d);
+
+        // removes project status column #25
+        overViewModule.getOverviewGrid().removeColumn("projectStatus");
     }
 
     /**
@@ -202,11 +203,11 @@ public class ProjectOVPresenter{
         filter.setTextFilter("projectID", true, true);
         filter.setDateFilter("rawDataRegistered", new SimpleDateFormat("yyyy-MM-dd"), true);
         filter.setTextFilter("offerID", true, true);
-        final List<String> projectStatus = new ArrayList<>();
-        projectStatus.add("open");
-        projectStatus.add("in progress");
-        projectStatus.add("closed");
-        filter.setComboBoxFilter("projectStatus", projectStatus);
+        //final List<String> projectStatus = new ArrayList<>();
+        //projectStatus.add("open");
+        //projectStatus.add("in progress");
+        //projectStatus.add("closed");
+        //filter.setComboBoxFilter("projectStatus", projectStatus);
         final List<String> generalStatus = new ArrayList<>();
         generalStatus.add("no");
         generalStatus.add("in progress");
@@ -225,7 +226,8 @@ public class ProjectOVPresenter{
      */
     private void initExtraHeaderRow(final Grid grid, final GridCellFilter filter){
         Grid.HeaderRow firstHeaderRow = grid.prependHeaderRow();
-        firstHeaderRow.join("projectID", "offerID", "projectStatus", "rawDataRegistered",
+        // "projectStatus removed (#25)
+        firstHeaderRow.join("projectID", "offerID", "rawDataRegistered",
                 "dataProcessed", "dataAnalyzed", "reportSent", "invoice");
         HorizontalLayout buttonLayout = new HorizontalLayout();
         buttonLayout.setSpacing(true);
@@ -257,7 +259,7 @@ public class ProjectOVPresenter{
     public void setFilter(String column, String filter){
         Container.Filter tmpFilter = new Like(column, filter);
         if(!contentModel.getTableContent().getContainerFilters().contains(tmpFilter)){
-            contentModel.getTableContent().removeContainerFilters("projectStatus");
+            //contentModel.getTableContent().removeContainerFilters("projectStatus");
             contentModel.getTableContent().addContainerFilter(new Like(column, filter));
         } else{
             contentModel.getTableContent().removeContainerFilter(tmpFilter);


### PR DESCRIPTION
The project status column turned out to be obsolete.

To use it as an optional feature in the future, the module is still present and
most of the lines were just uncommented. Removed code was
commented for an easy reuse of the module.

Resolves: #25